### PR TITLE
fix(coordinator): skip UPS monitor when no UPS unit is attached

### DIFF
--- a/custom_components/mikrotik_extended/coordinator.py
+++ b/custom_components/mikrotik_extended/coordinator.py
@@ -1971,9 +1971,18 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     def get_ups(self) -> None:
         """Get UPS info from Mikrotik"""
+        ups_data = self.api.query("/system/ups")
+        if not ups_data:
+            # The UPS package is installed but no UPS unit is configured or
+            # attached. Bail out so we never issue "/system/ups monitor" for a
+            # non-existent unit, which fails repeatedly and breaks the update
+            # cycle on setup. With an empty dict the singleton guard in
+            # entity.py skips creating the UPS entity. See issue #1.
+            self.ds["ups"] = {}
+            return
         self.ds["ups"] = parse_api(
             data=self.ds["ups"],
-            source=self.api.query("/system/ups"),
+            source=ups_data,
             vals=[
                 {"name": "name", "default": "unknown"},
                 {"name": "offline-time", "default": "unknown"},

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1418,6 +1418,21 @@ class TestMiscSensorGetters:
             coord.get_ups()
         assert coord.ds["ups"]["load"] == 50
 
+    def test_get_ups_no_unit_skips_monitor(self, hass):
+        # UPS package installed but no unit attached: "/system/ups" returns [].
+        # The getter must bail out without parsing or querying the monitor
+        # endpoint, leaving an empty dict so no UPS entity is created. See
+        # issue #1.
+        coord = _make_coordinator(hass)
+        coord.api.query = MagicMock(return_value=[])
+        with patch(
+            "custom_components.mikrotik_extended.coordinator.parse_api",
+        ) as mock_parse:
+            coord.get_ups()
+        coord.api.query.assert_called_once_with("/system/ups")
+        mock_parse.assert_not_called()
+        assert coord.ds["ups"] == {}
+
     def test_get_gps(self, hass):
         coord = _make_coordinator(hass)
         gps = {"valid": True, "latitude": "1", "longitude": "2"}


### PR DESCRIPTION
## Summary

Fixes #1 — integration fails to initialise (update loop) when the **UPS package is installed but no physical UPS is attached** (reported on RB4011 / RouterOS 7.23.1).

## Root cause

When no UPS unit is configured, `/system/ups` returns an empty list. `parse_api` then falls back to `fill_defaults`, where the `enabled` field is defined as `source="disabled", reverse=True`. With the `disabled` key entirely **absent**, the reverse logic resolves to `enabled = not False = True`.

`get_ups()` therefore believed a UPS was enabled and issued:

```
/system/ups monitor .id=0 once
```

against a non-existent unit, which fails repeatedly and breaks the coordinator update cycle during setup. The reporter's workaround was to remove the UPS package entirely.

## Fix

`get_ups()` now bails out early with an empty dict when `/system/ups` is empty:

- the broken monitor query against a non-existent unit is never issued;
- the singleton guard in `entity.py` (`data.get("on-line") is None → return`) skips creating the UPS entity — the desired behaviour when no UPS is present.

The **UPS-present path is unchanged**.

## Testing

- New regression test `test_get_ups_no_unit_skips_monitor`: an empty `/system/ups` response skips `parse_api` and the monitor query, leaving `ds["ups"] == {}`.
- Full suite: **619 passed**.
- `ruff check`: clean.

> Note: this targets only the no-UPS case; a UPS unit is not required to validate it, and the existing `enabled`/monitor branch tests cover the with-UPS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)