### PR TITLE
ci: fix sensitive-check diff failing on all PRs

### DIFF
--- a/.github/workflows/sensitive-check.yml
+++ b/.github/workflows/sensitive-check.yml
@@ -13,13 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          # Full history so the PR base commit is available for the diff below.
+          fetch-depth: 0
 
       - name: Get changed files
         id: changed
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+            # Diff against the explicit base SHA GitHub provides; the
+            # "origin/<branch>" ref is not guaranteed to exist on the runner.
+            FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
           else
             FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git ls-files)
           fi


### PR DESCRIPTION
## Problem

The **Sensitive Data Check** workflow fails on **every** pull request, before scanning anything:

```
fatal: ambiguous argument 'origin/master...HEAD': unknown revision or path not in the working tree
##[error]Process completed with exit code 128
```

The *Get changed files* step diffs `origin/${{ github.base_ref }}...HEAD`, but the checkout uses `fetch-depth: 2` (shallow), so the `origin/master` remote-tracking ref isn't present on the runner — the `git diff` aborts with exit 128 and the whole job goes red. This is a permanent false negative unrelated to PR content (observed on #3 and #4).

## Fix

- `fetch-depth: 0` so the PR base commit is in history.
- Diff against `${{ github.event.pull_request.base.sha }}` (the explicit base SHA GitHub provides) instead of the `origin/<branch>` named ref.

Non-PR (`push`) path is unchanged.

## Validation

- YAML parses (`yaml.safe_load`).
- Since `pull_request` workflows run from the PR merge ref, this PR's own Sensitive Data Check exercises the fixed logic — a green check here is the self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)