### PR TITLE
Recover interface switches from malformed API responses

### DIFF
--- a/custom_components/mikrotik_extended/mikrotikapi.py
+++ b/custom_components/mikrotik_extended/mikrotikapi.py
@@ -272,31 +272,32 @@ class MikrotikAPI:
         if not self.connection_check():
             return False
 
-        response = self.query(path, return_list=False)
-        if response is None:
-            return False
-
-        for tmp in response:
-            if param not in tmp:
-                continue
-
-            if tmp[param] != value:
-                continue
-
-            entry_found = tmp[".id"]
-
-        if not entry_found:
-            _LOGGER.warning(
-                "Mikrotik %s set_value parameter %s with value %s not found",
-                self._host,
-                param,
-                value,
-            )
-            return False
-
-        params = {".id": entry_found, mod_param: mod_value}
         with self.lock:
             try:
+                _LOGGER.debug("API query: %s", path)
+                response = self._connection.path(path)
+                if not response:
+                    return False
+
+                for tmp in response:
+                    if param not in tmp:
+                        continue
+
+                    if tmp[param] != value:
+                        continue
+
+                    entry_found = tmp[".id"]
+
+                if not entry_found:
+                    _LOGGER.warning(
+                        "Mikrotik %s set_value parameter %s with value %s not found",
+                        self._host,
+                        param,
+                        value,
+                    )
+                    return False
+
+                params = {".id": entry_found, mod_param: mod_value}
                 response.update(**params)
             except Exception as e:
                 self.disconnect("set_value", e)

--- a/tests/test_mikrotikapi.py
+++ b/tests/test_mikrotikapi.py
@@ -398,6 +398,17 @@ class TestSetValue:
         assert result is False
         assert self.api.connected() is False
 
+    def test_set_value_iteration_exception_disconnects(self):
+        """A malformed RouterOS response must invalidate the connection."""
+        mock_path = MagicMock()
+        mock_path.__iter__ = MagicMock(side_effect=ValueError("not enough values to unpack (expected 3, got 2)"))
+        self.api._connection.path.return_value = mock_path
+
+        result = self.api.set_value("/interface", "name", "eth0", "disabled", True)
+
+        assert result is False
+        assert self.api.connected() is False
+
 
 class TestExecute:
     def setup_method(self):


### PR DESCRIPTION
## Proposed change

Prevent interface switch updates from leaving the librouteros session in a broken but apparently connected state.

`set_value()` previously created the API path while holding the connection lock, but iterated the RouterOS response after releasing it. If response parsing raised an exception such as `timed out` or `not enough values to unpack (expected 3, got 2)`, the exception bypassed the existing update error handler. The connection therefore remained marked as connected and subsequent coordinator refreshes could keep reusing the damaged session until Home Assistant was restarted.

This change keeps path creation, response iteration, and the update command in one locked error-handling block. Any exception now invalidates the connection, allowing the following coordinator refresh to reconnect normally.

Fixes #18.

## Type of change

- [x] Bugfix
- [x] Code quality improvements to existing code or addition of tests
- [ ] New feature
- [ ] Documentation

## Additional information

A regression test reproduces the exact response parsing exception from the Home Assistant automation trace and verifies that it is handled without propagating while the failed connection is invalidated.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code passes the project's Ruff lint and formatting checks.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation is not required for this internal error-recovery change.

Local verification: `671 passed`.
