### PR TITLE
fix: connect fails with 'cannot_connect' on Home Assistant (librouteros 4.x compatibility)

### DIFF
--- a/custom_components/mikrotik_extended/const.py
+++ b/custom_components/mikrotik_extended/const.py
@@ -16,6 +16,9 @@ DEFAULT_NAME = "MikroTik Extended"
 ATTRIBUTION = "Data provided by Mikrotik"
 
 DEFAULT_ENCODING = "ISO-8859-1"
+# Supported login methods: "plain" (RouterOS >=6.43) and "token" (legacy
+# pre-6.43 challenge login). The name is mapped to a librouteros callable in
+# mikrotikapi.py; keep the values in sync with that map.
 DEFAULT_LOGIN_METHOD = "plain"
 
 # Fallback codepage for free-text fields (comments, host names, SSIDs) that are

--- a/custom_components/mikrotik_extended/manifest.json
+++ b/custom_components/mikrotik_extended/manifest.json
@@ -11,7 +11,7 @@
     "issue_tracker": "https://github.com/Csontikka/ha-mikrotik-extended/issues",
     "quality_scale": "silver",
     "requirements": [
-        "librouteros>=3.4.1,<4.0.0",
+        "librouteros>=3.4.1,<5.0.0",
         "mac-vendor-lookup>=0.1.12,<0.2.0"
     ],
     "version": "0.6.4"

--- a/custom_components/mikrotik_extended/mikrotikapi.py
+++ b/custom_components/mikrotik_extended/mikrotikapi.py
@@ -142,9 +142,17 @@ class MikrotikAPI:
 
         kwargs = {
             "encoding": self._encoding,
-            "login_methods": self._login_method,
             "port": self._port,
         }
+        # librouteros wants the callable under ``login_method`` (singular). The
+        # old ``login_methods`` key was silently ignored by librouteros <4 (which
+        # accepted **kwargs) but is rejected outright by librouteros >=4, whose
+        # connect() is keyword-only. That rejection surfaced to the user as a
+        # generic "cannot_connect". Home Assistant ships librouteros 4.x, so
+        # resolve the configured method to a callable and pass it correctly.
+        login_method = _LOGIN_METHODS.get(self._login_method)
+        if login_method is not None:
+            kwargs["login_method"] = login_method
 
         with self.lock:
             try:

--- a/custom_components/mikrotik_extended/mikrotikapi.py
+++ b/custom_components/mikrotik_extended/mikrotikapi.py
@@ -8,6 +8,7 @@ from threading import Lock
 from time import sleep, time
 
 import librouteros
+import librouteros.login as _rlogin
 from voluptuous import Optional
 
 from .const import (
@@ -18,6 +19,13 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 SCRIPT_ENVIRONMENT_PATH = "/system/script/environment"
+
+# librouteros expects a *callable* for its ``login_method`` argument (singular).
+# Map the configured method name (see DEFAULT_LOGIN_METHOD) to that callable so a
+# plain config string is never handed straight to librouteros.
+_LOGIN_METHODS = {"plain": _rlogin.plain}
+if hasattr(_rlogin, "token"):  # legacy pre-6.43 challenge login
+    _LOGIN_METHODS["token"] = _rlogin.token
 
 
 # ---------------------------


### PR DESCRIPTION
## Summary

Setting up the integration currently fails at the connection step with a generic **`cannot_connect`** error on any up‑to‑date Home Assistant install — no matter what host, port, SSL mode or credentials you enter. This PR fixes that.

The cause is a one‑word bug in how the RouterOS API login is handed to `librouteros`. It was harmless for years and only became **fatal** once Home Assistant upgraded its bundled `librouteros` to the 4.x series.

Verified end‑to‑end against a live RouterOS device (API on `8728`, non‑SSL) with **both `librouteros` 3.4.3 and 4.1.1** — connect and real queries succeed on both after the fix.

---

## The problem (in detail)

`MikrotikAPI.connect()` builds the arguments for `librouteros.connect()` like this:

```python
kwargs = {
    "encoding": self._encoding,
    "login_methods": self._login_method,   # <-- the bug
    "port": self._port,
}
...
self._connection = librouteros.connect(self._host, self._username, self._password, **kwargs)
```

Two things are wrong with `"login_methods": self._login_method`:

1. **Wrong argument name.** `librouteros.connect()` has no `login_methods` (plural) parameter. The real one is **`login_method`** (singular).
2. **Wrong value type.** `login_method` expects a **callable** (e.g. `librouteros.login.plain`), not the **string** `"plain"` that `DEFAULT_LOGIN_METHOD` provides.

### Why it used to work and breaks now

- **librouteros < 4** — `connect()` accepted `**kwargs`, so the unknown `login_methods` key was **silently ignored**. Login fell back to the library default (`plain`) and everything worked by accident. The wrong value type never mattered because the value was never actually used.
- **librouteros ≥ 4** — `connect()` was rewritten with an explicit **keyword‑only** signature and **no** `**kwargs`:

  ```
  connect(host, username, password, *, timeout=10, port=8728, saddr=None,
          subclass=Api, encoding='ASCII', ssl_wrapper=None, login_method=<plain>)
  ```

  Passing `login_methods=...` now raises immediately:

  ```
  TypeError: connect() got an unexpected keyword argument 'login_methods'
  ```

`connect()` catches every exception and runs it through `error_to_strings()`, which maps anything that isn't a known auth/SSL message to the generic **`cannot_connect`**. So the real `TypeError` is swallowed and the user is told "cannot connect" — with no hint that host/port/credentials were fine all along.

### Why this now hits everyone

Home Assistant Core's built‑in `mikrotik` integration depends on **`librouteros==4.1.1`**, and HA pins that exact version through its constraints file. Because this integration's manifest asked for `librouteros>=3.4.1,<4.0.0`, HA can't install a 3.x build (the core pin wins) — so the integration ends up **running against 4.1.1**, the exact version where the bug is fatal. Net result on any current Home Assistant: setup fails with `cannot_connect` **100% of the time**, and the config dialog gives no clue why.

---

## The fix — explained simply (for non‑developers)

Think of `librouteros.connect()` as a form you fill in to log into the router. One field asks *"how should I log in?"*.

- The old code wrote the answer into a field called **"login methods"** (with an *s*), and wrote the plain word **"plain"** as text.
- The library's form actually has a field called **"login method"** (no *s*), and it doesn't want the *word* "plain" — it wants you to hand it the **actual login procedure** to run.

Older library versions were forgiving: scribble an answer into a field that doesn't exist and they just ignore it and use the normal login — so it happened to work. The new version is strict: write into a field that doesn't exist and it throws the whole form back ("I don't know what 'login methods' is"). Our integration saw that rejection, shrugged, and reported **"cannot connect"** — even though the username, password and address were perfectly fine.

The fix does three small things:

1. **Keep a tiny lookup table** that turns the setting `"plain"` (or `"token"`) into the real login procedure the library expects.
2. **Fill in the correctly‑named field** — `login_method` (singular) — with that procedure.
3. **Allow the new library version** in `manifest.json` so Home Assistant stops trying (and failing) to force an old one.

Because plain login is also the library's default, existing users see **no behaviour change** — the integration simply stops crashing on the current library.

---

## Changes

Split into small, self‑contained commits for easy review:

| Commit | What |
|---|---|
| `fix(api): add a resolver from login-method name to librouteros callable` | Add a `name → callable` map (`_LOGIN_METHODS`) using `librouteros.login.plain` / `.token`. |
| `fix(api): pass login_method callable to connect() (fixes librouteros >=4)` | Drop the bogus `login_methods` key; pass the resolved callable under `login_method`. |
| `fix(manifest): allow librouteros 4.x` | `librouteros>=3.4.1,<4.0.0` → `>=3.4.1,<5.0.0`. |
| `docs(const): document supported login methods` | Note the accepted `DEFAULT_LOGIN_METHOD` values. |

---

## Compatibility

- Works on **librouteros 3.4.x and 4.x** (tested on 3.4.3 and 4.1.1 against real hardware).
- **No behaviour change** for existing users: `plain` stays the default and resolves to `librouteros.login.plain`.
- `token` (the legacy pre‑6.43 challenge login) is wired up too, guarded with `hasattr` so it's only registered if the installed librouteros still ships it.

## Testing

- Reproduced the original `TypeError` → `cannot_connect` against librouteros **4.1.1**.
- Confirmed the fix connects and runs real queries (`/system/identity`, `/system/resource`, `/interface`, `/ip/address`) on **both** librouteros **3.4.3 and 4.1.1**, same host, port `8728`, non‑SSL.
- `ruff check` with the repo config passes; changed files compile; no existing test references the old argument.
